### PR TITLE
Added highlighting for directives from newer MADS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # MADS assembly
 
-It provides syntax highlighting for [MADS](http://mads.atari8.info/), powerful multi-pass cross assembler designed for 6502 and 65816 processors.
-
-## Features
-
-It supports all features of MADS v2.0.6
+It provides syntax highlighting for [MADS 2.1.5](http://mads.atari8.info/), powerful multi-pass cross assembler designed for 6502 and 65816 processors.
 
 ![Example](images/example.png)
 

--- a/syntaxes/mads.tmLanguage
+++ b/syntaxes/mads.tmLanguage
@@ -249,7 +249,7 @@
                 <array>
                     <dict>
                         <key>match</key>
-                        <string>(?i)\s+dta|((^|\s+|(?&lt;=\())\.(d?byte|d?word|long)|(^|\s+)\.((zp)?var|reg|db|dw|by|ds|sb|cb|wo|he|fl))\b</string>
+                        <string>(?i)\s+dta|((^|\s+|(?&lt;=\())\.(d?byte|d?word|long)|(^|\s+)\.((zp)?var|reg|db|dw|by|ds|sb|cbm?|wo|he|fl|a8|a16|ai8|ai16|i8|i16|ia8|ia16|long[ai] (on|off)))\b</string>
                         <key>name</key>
                         <string>storage.type</string>
                     </dict>
@@ -273,7 +273,7 @@
                 <array>
                     <dict>
                         <key>match</key>
-                        <string>(?i)(\bset|\.(adr|len|sizeof|filesize|def))\b</string>
+                        <string>(?i)(\bset|\.(adr|len|sizeof|filesize|fileexists|def|asize|isize|rnd))\b</string>
                         <key>name</key>
                         <string>keyword.other.label.functions</string>
                     </dict>


### PR DESCRIPTION
- 2.0.7: Directives (65816): .A8, .A16, .I8, .I16, .AI8, .IA8, .AI16, .IA16, .ASIZE, .ISIZE
- 2.0.8: Directives (65816): .LONGA ON|OFF, .LONGI ON|OFF
- 2.0.9: Directive .cbm
- 2.1.0: Directive .FILEEXISTS
- 2.1.3: Directive .rnd